### PR TITLE
chore: omit print when typing can't pull in

### DIFF
--- a/adafruit_ms8607.py
+++ b/adafruit_ms8607.py
@@ -40,11 +40,11 @@ from adafruit_bus_device import i2c_device
 
 try:
     """Needed for type annotations"""
-    from busio import I2C
     from typing import Tuple, Any
 
+    from busio import I2C
 except ImportError:
-    print("Couldnt import")
+    pass
 
 
 _MS8607_HSENSOR_ADDR = const(0x40)  #


### PR DESCRIPTION
there's currently a print statement that's used when an import error occurs during an import for typing.  other libraries - such as `adafruit_rsa` and `adafruit_pcd8544` will silently ignore the import issues because it's expected on a circuitpython board for typing to not exist.

also updates the order for typing imports so the busio I2C import (only used for typing) isn't pulled in at all if we can't use typing

previous behavior: any time this library is used on circuitpython a confusing `Couldn't import` is emitted into the log or onto the associated screen

new behavior: *crickets* (and maybe a few bytes less memory because we don't pull in I2C from busio if we don't need to)